### PR TITLE
Fix prom_read to use a measurement name as a backend key as prom_write

### DIFF
--- a/service/http.go
+++ b/service/http.go
@@ -478,7 +478,7 @@ func (hs *HttpService) HandlerPromRead(w http.ResponseWriter, req *http.Request)
 	q := readReq.Queries[0]
 	for _, m := range q.Matchers {
 		if m.Name == "__name__" {
-			metric = m.Name
+			metric = m.Value
 		}
 	}
 	if metric == "" {


### PR DESCRIPTION
Like `hs.HandlerPromWrite` using a point measurement name as a proxy backend key, `hs.HandlerPromRead` has a bug which always uses `__name__` as a proxy backend key

